### PR TITLE
feat(bot): Log bot into Steam account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+config/
 node_modules/
 npm-debug.log*

--- a/bin/cheevobot.js
+++ b/bin/cheevobot.js
@@ -10,5 +10,5 @@ const SteamBot = require('../lib/steam-bot')
 const cheevobot = new SteamBot()
 cheevobot.start(err => {
   if (err) throw err
-  console.log('connected')
+  console.log('logged in')
 })

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -2,7 +2,11 @@
 
 // -- Dependencies -------------------------------------------------------------
 
+// Node.js API
+const path = require('path')
+
 // Node packaged modules
+const confit = require('confit')
 const SteamClient = require('steam-client')
 
 // -- Public Interface ---------------------------------------------------------
@@ -28,12 +32,24 @@ class SteamBot {
    * Starts the bot by connecting the client to the Steam network.
    *
    * @since 0.1.0
-   * @param {Function} callback - Continuation function after connecting
+   * @param {Function} callback - Continuation function after logging in
    * @returns {void}
   **/
   start (callback) {
-    this._client.connect()
-    this._client.on('connected', callback)
+    confit(path.resolve('config/')).create((err, config) => {
+      if (err) return callback(err)
+
+      this._client.steamID = config.get('steam_id')
+      this._client.connect()
+      this._client.on('connected', _ => {
+        this._client.logOn(config.get('login'))
+        this._client.on('logOnResponse', response => {
+          response.eresult !== SteamClient.EResult.OK
+            ? callback(new Error('Login response: ' + response.eresult))
+            : callback()
+        })
+      })
+    })
   }
 
   //

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "confit": "^2.0.0",
     "steam-client": "^2.0.0"
   },
   "engines": {


### PR DESCRIPTION
Log the bot into its account on the Steam network. Support for
two-factor authentication has not been tested, and the bot configuration
needs to manually be created in "config/config.json".

Example of what the wrapper initially expects from the config file:

```
{
  "steam_id": "<steam_id>",
  "login": {
    "account_name": "<account_name>",
    "password": "<password>"
  }
}
```

After the first attempt returns an error response of `63`, an
authentication code (sent to the email registered to the bot's account)
is required:

```
{
  "steam_id": "<steam_id>",
  "login" {
    "account_name": "<account_name>",
    "password": "<password>",
    "auth_code": "<auth_code>"
  }
}
```