### PR TITLE
feat(bot): Prompt user for Steam Guard code

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -7,7 +7,9 @@ const path = require('path')
 
 // Node packaged modules
 const confit = require('confit')
-const SteamClient = require('steam-client')
+
+// Local modules
+const SteamUser = require('steam-user')
 
 // -- Public Interface ---------------------------------------------------------
 
@@ -25,30 +27,25 @@ class SteamBot {
    * @since 0.1.0
   **/
   constructor () {
-    this._client = new SteamClient.CMClient()
+    this._client = new SteamUser()
   }
 
   /**
-   * Starts the bot by connecting the client to the Steam network.
+   * Starts the bot by logging into its Steam account.
    *
    * @since 0.1.0
-   * @param {Function} callback - Continuation function after logging in
+   * @param {Function} cb - Continuation function after logging in
    * @returns {void}
   **/
-  start (callback) {
+  start (cb) {
     confit(path.resolve('config/')).create((err, config) => {
-      if (err) return callback(err)
-
-      this._client.steamID = config.get('steam_id')
-      this._client.connect()
-      this._client.on('connected', _ => {
-        this._client.logOn(config.get('login'))
-        this._client.on('logOnResponse', response => {
-          response.eresult !== SteamClient.EResult.OK
-            ? callback(new Error('Login response: ' + response.eresult))
-            : callback()
-        })
-      })
+      if (err) return cb(err)
+      this._client.logOn(config.get('login'))
+      this._client.on('loggedOn', response => {
+        response.eresult !== SteamUser.EResult.OK
+          ? cb(new Error('Login response: ' + response.eresult))
+          : cb()
+      });
     })
   }
 
@@ -61,7 +58,7 @@ class SteamBot {
    *
    * @private
    * @memberof SteamBot
-   * @member {SteamClient.CMClient} _client
+   * @member {SteamClient} _client
   **/
 }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "confit": "^2.0.0",
-    "steam-client": "^2.0.0"
+    "steam-user": "^3.0.0"
   },
   "devDependencies": {
     "standard": "^8.0.0"


### PR DESCRIPTION
The user is now prompted for the Steam Guard code and the bot no longer
requires a second, manual login attempt in order to provide it.

This means that `login.auth_code` has been removed as a required field
from the bot's config file. The bot's Steam ID also no longer needs to
be explicitly set and the `steam_id` option has been removed.