### PR TITLE
feat(bot): Set the bot's state to online

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -7,8 +7,6 @@ const path = require('path')
 
 // Node packaged modules
 const confit = require('confit')
-
-// Local modules
 const SteamUser = require('steam-user')
 
 // -- Public Interface ---------------------------------------------------------
@@ -42,9 +40,8 @@ class SteamBot {
       if (err) return cb(err)
       this._client.logOn(config.get('login'))
       this._client.on('loggedOn', response => {
-        response.eresult !== SteamUser.EResult.OK
-          ? cb(new Error('Login response: ' + response.eresult))
-          : cb()
+        this._client.setPersona(SteamUser.EPersonaState.Online)
+        cb()
       })
     })
   }


### PR DESCRIPTION
The bot's state needs to be explicitly set in order to appear online.

Error checking within the listener to the `loggedOn` event has been
removed, as this event is only emitted if the login attempt was
successful.