### PR TITLE
test(bot): Add unit tests for `SteamBot`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
   },
   "repository": "scriptdaemon/cheevobot",
   "scripts": {
-    "test": "standard"
+    "test": "standard && tap \"test/**/*.test.js\""
   },
   "dependencies": {
     "confit": "^2.0.0",
     "steam-user": "^3.0.0"
   },
   "devDependencies": {
-    "standard": "^8.0.0"
+    "standard": "^8.0.0",
+    "tap": "^10.0.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// -- Dependencies -------------------------------------------------------------
+
+// Node packaged modules
+const tap = require('tap')
+
+// Local modules
+const SteamBot = require('../../lib/steam-bot')
+
+// -- Tests --------------------------------------------------------------------
+
+tap.test('SteamBot', tap => {
+  const bot = new SteamBot()
+  bot._client.logOn = login => {
+    process.nextTick(_ => {
+      bot._client.emit('loggedOn')
+    })
+  }
+
+  tap.test('#start', tap => {
+    tap.test('should not pass an error', tap => {
+      bot.start(err => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+    tap.end()
+  })
+
+  tap.end()
+})


### PR DESCRIPTION
This will need to be refactored to use separate fixtures for any
component related to the connection between the client and the Steam
network, but this at least verifies the `config` option is created.