### PR TITLE
feat(bot): Add a command parser

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -8,6 +8,7 @@ const path = require('path')
 // Node packaged modules
 const confit = require('confit')
 const SteamUser = require('steam-user')
+const yargs = require('yargs/yargs')
 
 // -- Public Interface ---------------------------------------------------------
 
@@ -20,16 +21,19 @@ const SteamUser = require('steam-user')
 class SteamBot {
 
   /**
-   * Creates a bot wrapper for a new Steam client instance.
+   * Create a bot wrapper for a new Steam client instance.
    *
    * @since 0.1.0
   **/
   constructor () {
     this._client = new SteamUser()
+    this._client.on('friendOrChatMessage', (sender, msg, chat) => {
+      this.exec(msg, { sender, chat })
+    })
   }
 
   /**
-   * Starts the bot by logging into its Steam account.
+   * Start the bot by logging into its Steam account.
    *
    * @since 0.1.0
    * @param {Function} cb - Continuation function after logging in
@@ -38,11 +42,34 @@ class SteamBot {
   start (cb) {
     confit(path.resolve('config/')).create((err, config) => {
       if (err) return cb(err)
+
+      // Build command parser
+      this._parser = yargs()
+      this._parser.help()
+      this._parser.version()
+
       this._client.logOn(config.get('login'))
       this._client.on('loggedOn', response => {
         this._client.setPersona(SteamUser.EPersonaState.Online)
         cb()
       })
+    })
+  }
+
+  /**
+   * Execute a command.
+   *
+   * @since 0.1.0
+   * @param {string} cmd - Raw command
+   * @param {Object} context - Context information
+   * @returns {void}
+  **/
+  exec (cmd, context) {
+    this._parser.parse(cmd, context, (err, argv, output) => {
+      const msg = err ? err.message : output
+      if (msg) {
+        this._client.chatMessage(argv.chat, msg)
+      }
     })
   }
 
@@ -56,6 +83,14 @@ class SteamBot {
    * @private
    * @memberof SteamBot
    * @member {SteamUser} _client
+  **/
+
+  /**
+   * Command parser.
+   *
+   * @private
+   * @memberof SteamBot
+   * @member {Yargs} _parser
   **/
 }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "confit": "^2.0.0",
-    "steam-user": "^3.0.0"
+    "steam-user": "^3.0.0",
+    "yargs": "^6.1.1"
   },
   "devDependencies": {
     "standard": "^8.0.0",

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -28,5 +28,25 @@ tap.test('SteamBot', tap => {
     tap.end()
   })
 
+  tap.test('#exec', tap => {
+    tap.test('should display help message', tap => {
+      bot.exec('--help', (err, argv, output) => {
+        tap.error(err)
+        tap.ok(argv.help)
+        tap.end()
+      })
+    })
+
+    tap.test('should display version info', tap => {
+      bot.exec('--version', (err, argv, output) => {
+        tap.error(err)
+        tap.ok(argv.version)
+        tap.end()
+      })
+    })
+
+    tap.end()
+  })
+
   tap.end()
 })


### PR DESCRIPTION
Allow the bot to accept and respond to commands issued to it via Steam
user and group chat rooms.

Currently, the only supported commands / options are `--version` and
variations of `help` (e.g. `help` and `--help`).