### PR TITLE
feat(cmd): Add `dice` command

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -1,0 +1,49 @@
+'use strict'
+
+// -- Dependencies -------------------------------------------------------------
+
+// Node packaged modules
+const chance = require('chance')
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Command to simulate a dice roll. Responds with the result of each die roll as
+ * a single, space-delimited string.
+ *
+ * Accepts one (1) optional argument:
+ *  * roll (default: '1d6')
+ *    - Expects a string in #d# format; the first # is the number of dice to
+ *    - roll and the second # is the max of each die. This value is coerced to a
+ *    - single, space-delimited string of the result rolls of each die.
+ *
+ * @since 0.2.0
+ * @param {SteamBot} bot - Bot instance
+ * @returns {Object} Command object in yargs format
+ * @example
+ *
+ * dice
+ * // => '3'
+ *
+ * dice 3d6
+ * // => '4 2 5'
+**/
+function dice (bot) {
+  return {
+    'command': 'dice [roll]',
+    'description': 'Simulate a dice roll',
+
+    builder (yargs) {
+      yargs.option('roll', { 'default': '1d6', 'type': 'string' })
+      yargs.coerce('roll', arg => chance().rpg(arg).join(' '))
+    },
+
+    handler (argv) {
+      bot._client.chatMessage(argv.chat, argv.roll)
+    }
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = dice

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -10,6 +10,9 @@ const confit = require('confit')
 const SteamUser = require('steam-user')
 const yargs = require('yargs/yargs')
 
+// Local modules
+const dice = require('./plugins/cmds/dice')
+
 // -- Public Interface ---------------------------------------------------------
 
 /**
@@ -45,6 +48,7 @@ class SteamBot {
 
       // Build command parser
       this._parser = yargs()
+      this._parser.command(dice(this))
       this._parser.help()
       this._parser.version()
 
@@ -66,9 +70,9 @@ class SteamBot {
   **/
   exec (cmd, context) {
     this._parser.parse(cmd, context, (err, argv, output) => {
-      const msg = err ? err.message : output
-      if (msg) {
-        this._client.chatMessage(argv.chat, msg)
+      if (err) throw err
+      if (output) {
+        this._client.chatMessage(argv.chat, output)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "standard && tap \"test/**/*.test.js\""
   },
   "dependencies": {
+    "chance": "^1.0.0",
     "confit": "^2.0.0",
     "steam-user": "^3.0.0",
     "yargs": "^6.1.1"


### PR DESCRIPTION
Add a command to simulate a dice roll. The command accepts a string
parameter of the form "#d#" where the first # is the number of dice to
roll and the second # is the max value of each die. The default roll is
`1d6` for a single, standard d6 die.

This includes a fix involving the parser short-circuit function; when
the parser passes an error, the arguments object is null and therefore
the context does not exist.