### PR TITLE
fix(bot): Fix crash when issued a bad command

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -17,7 +17,7 @@ const chance = require('chance')
  *    - roll and the second # is the max of each die. This value is coerced to a
  *    - single, space-delimited string of the result rolls of each die.
  *
- * @since 0.2.0
+ * @since 0.1.0
  * @param {SteamBot} bot - Bot instance
  * @returns {Object} Command object in yargs format
  * @example

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -72,9 +72,9 @@ class SteamBot {
   **/
   exec (cmd, context) {
     this._parser.parse(cmd, context, (err, argv, output) => {
-      if (err) throw err
-      if (output) {
-        this._client.chatMessage(argv.chat, output)
+      const msg = err ? err.message : output
+      if (msg) {
+        this._client.chatMessage(context.chat, msg)
       }
     })
   }


### PR DESCRIPTION
Don't throw in response to an error when executing a command. Instead,
use the chat object from the context directly since the context will
always be available.