### PR TITLE
fix(bot): Show full help on bad command

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -39,7 +39,7 @@ function dice (bot) {
     },
 
     handler (argv) {
-      bot._client.chatMessage(argv.chat, argv.roll)
+      bot._client.chatMessage(argv.room, argv.roll)
     }
   }
 }

--- a/lib/plugins/cmds/uptime.js
+++ b/lib/plugins/cmds/uptime.js
@@ -19,7 +19,7 @@ function uptime (bot) {
     'description': 'Retrieve bot uptime',
 
     handler (argv) {
-      bot._client.chatMessage(argv.chat, `Bot uptime: ${process.uptime()}s`)
+      bot._client.chatMessage(argv.room, `Bot uptime: ${process.uptime()}s`)
     }
   }
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -31,8 +31,8 @@ class SteamBot {
   **/
   constructor () {
     this._client = new SteamUser()
-    this._client.on('friendOrChatMessage', (sender, msg, chat) => {
-      this.exec(msg, { sender, chat })
+    this._client.on('friendOrChatMessage', (sender, msg, room) => {
+      this.exec(msg, { sender, room })
     })
   }
 
@@ -67,14 +67,14 @@ class SteamBot {
    *
    * @since 0.1.0
    * @param {string} cmd - Raw command
-   * @param {Object} context - Context information
+   * @param {Object} context - Message context information
    * @returns {void}
   **/
   exec (cmd, context) {
     this._parser.parse(cmd, context, (err, argv, output) => {
-      const msg = err ? err.message : output
-      if (msg) {
-        this._client.chatMessage(context.chat, msg)
+      if (err && !output) throw err
+      if (output) {
+        this._client.chatMessage(context.room, output)
       }
     })
   }
@@ -84,7 +84,7 @@ class SteamBot {
   //
 
   /**
-   * Steam client object.
+   * Steam client.
    *
    * @private
    * @memberof SteamBot


### PR DESCRIPTION
Show full help message when a Steam user issues a bad command (e.g.
missing required argument). If an error was passed without an output
message, then the bot can safely assume the error is a programming
error.