### PR TITLE
test(bot): Create separate module for stub client

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -74,7 +74,7 @@ class SteamBot {
     this._parser.parse(cmd, context, (err, argv, output) => {
       if (err && !output) throw err
       if (output) {
-        this._client.chatMessage(context.room, output)
+        this._client.chatMsg(context.room, output)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "yargs": "^6.1.1"
   },
   "devDependencies": {
+    "proxyquire": "^1.5.0",
     "standard": "^8.0.0",
     "tap": "^10.0.0"
   },

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -3,50 +3,41 @@
 // -- Dependencies -------------------------------------------------------------
 
 // Node packaged modules
+const proxyquire = require('proxyquire')
 const tap = require('tap')
 
 // Local modules
-const SteamBot = require('../../lib/steam-bot')
+const SteamUser = require('../stub/steam-user.stub')
+
+// -- Helpers ------------------------------------------------------------------
+
+const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
 
 // -- Tests --------------------------------------------------------------------
 
 tap.test('SteamBot', tap => {
-  const bot = new SteamBot()
-  bot._client.logOn = login => {
-    process.nextTick(_ => {
-      bot._client.emit('loggedOn')
-    })
-  }
+  tap.plan(2)
 
-  tap.test('#start', tap => {
-    tap.test('should not pass an error', tap => {
-      bot.start(err => {
-        tap.error(err)
-        tap.end()
-      })
+  //
+  // Methods
+  //
+
+  tap.test('#start should not pass an error', tap => {
+    const bot = new SteamBot()
+    bot.start(err => {
+      tap.error(err)
+      tap.end()
     })
-    tap.end()
   })
 
-  tap.test('#exec', tap => {
-    tap.test('should display help message', tap => {
+  tap.test('#exec should not pass an error', tap => {
+    const bot = new SteamBot()
+    bot.start(err => {
+      tap.error(err)
       bot.exec('--help', (err, argv, output) => {
         tap.error(err)
-        tap.ok(argv.help)
         tap.end()
       })
     })
-
-    tap.test('should display version info', tap => {
-      bot.exec('--version', (err, argv, output) => {
-        tap.error(err)
-        tap.ok(argv.version)
-        tap.end()
-      })
-    })
-
-    tap.end()
   })
-
-  tap.end()
 })

--- a/test/stub/steam-user.stub.js
+++ b/test/stub/steam-user.stub.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// -- Dependencies -------------------------------------------------------------
+
+// Node.js API
+const EventEmitter = require('events')
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * SteamUser stub.
+**/
+class SteamUser extends EventEmitter {
+
+  /**
+   * SteamUser#logOn stub.
+   *
+   * @private
+   * @param {Object} login - Login details
+   * @returns {void}
+  **/
+  logOn (login) {
+    process.nextTick(_ => {
+      this.emit('loggedOn')
+    })
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = SteamUser


### PR DESCRIPTION
Separate stub client from tests. Reduce tests until later refactor, as
commands will be tested outside of the unit tests.

Create a new instance of the bot for each test to verify a fresh
environment is being used for each test.