### PR TITLE
feat(bot): Allow the bot to gracefully disconnect

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -63,6 +63,22 @@ class SteamBot {
   }
 
   /**
+   * Stop the bot by logging out and closing the connection.
+   *
+   * @since 0.1.0
+   * @param {Function} cb - Continuation function after disconnecting
+   * @returns {void}
+  **/
+  stop (cb) {
+    this._client.logOff()
+    this._client.on('disconnected', (eresult, msg) => {
+      eresult === 0
+        ? cb(new Error(msg))
+        : cb()
+    })
+  }
+
+  /**
    * Execute a command.
    *
    * @since 0.1.0

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -16,7 +16,7 @@ const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
 // -- Tests --------------------------------------------------------------------
 
 tap.test('SteamBot', tap => {
-  tap.plan(2)
+  tap.plan(3)
 
   //
   // Methods
@@ -25,6 +25,14 @@ tap.test('SteamBot', tap => {
   tap.test('#start should not pass an error', tap => {
     const bot = new SteamBot()
     bot.start(err => {
+      tap.error(err)
+      tap.end()
+    })
+  })
+
+  tap.test('#stop should not pass an error', tap => {
+    const bot = new SteamBot()
+    bot.stop(err => {
       tap.error(err)
       tap.end()
     })

--- a/test/stub/steam-user.stub.js
+++ b/test/stub/steam-user.stub.js
@@ -24,6 +24,18 @@ class SteamUser extends EventEmitter {
       this.emit('loggedOn')
     })
   }
+
+  /**
+   * SteamUser#logOff stub.
+   *
+   * @private
+   * @returns {void}
+  **/
+  logOff () {
+    process.nextTick(_ => {
+      this.emit('disconnected')
+    })
+  }
 }
 
 // -- Exports ------------------------------------------------------------------


### PR DESCRIPTION
Add a method to allow the bot to gracefully log out of its account and
disconnect from the Steam network.