### PR TITLE
style(bot): Avoid magic numbers

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -72,7 +72,7 @@ class SteamBot {
   stop (cb) {
     this._client.logOff()
     this._client.on('disconnected', (eresult, msg) => {
-      eresult === 0
+      eresult === SteamUser.EResult.Invalid
         ? cb(new Error(msg))
         : cb()
     })


### PR DESCRIPTION
Use pre-defined invalid result value rather than `0` directly.