### PR TITLE
feat(bot): Add root command namespace

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -8,8 +8,8 @@ const chance = require('chance')
 // -- Public Interface ---------------------------------------------------------
 
 /**
- * Command to simulate a dice roll. Responds with the result of each die roll as
- * a single, space-delimited string.
+ * Simulate a dice roll. Responds with the result of each die roll as a single,
+ * space-delimited string.
  *
  * Accepts one (1) optional argument:
  *  * roll (default: '1d6')
@@ -39,7 +39,7 @@ function dice (bot) {
     },
 
     handler (argv) {
-      bot._client.chatMessage(argv.room, argv.roll)
+      bot._client.chatMsg(argv.room, argv.roll)
     }
   }
 }

--- a/lib/plugins/cmds/uptime.js
+++ b/lib/plugins/cmds/uptime.js
@@ -3,7 +3,7 @@
 // -- Public Interface ---------------------------------------------------------
 
 /**
- * Command to retrieve the bot's uptime.
+ * Show the bot's uptime.
  *
  * @since 0.1.0
  * @param {SteamBot} bot - Bot instance
@@ -16,10 +16,10 @@
 function uptime (bot) {
   return {
     'command': 'uptime',
-    'description': 'Retrieve bot uptime',
+    'description': 'Show bot uptime',
 
     handler (argv) {
-      bot._client.chatMessage(argv.room, `Bot uptime: ${process.uptime()}s`)
+      bot._client.chatMsg(argv.room, `Bot uptime: ${process.uptime()}s`)
     }
   }
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -10,10 +10,6 @@ const confit = require('confit')
 const SteamUser = require('steam-user')
 const yargs = require('yargs/yargs')
 
-// Local modules
-const dice = require('./plugins/cmds/dice')
-const uptime = require('./plugins/cmds/uptime')
-
 // -- Public Interface ---------------------------------------------------------
 
 /**
@@ -37,7 +33,8 @@ class SteamBot {
   }
 
   /**
-   * Start the bot by logging into its Steam account.
+   * Start the bot by connecting to the Steam network and logging into the bot's
+   * Steam account.
    *
    * @since 0.1.0
    * @param {Function} cb - Continuation function after logging in
@@ -47,15 +44,19 @@ class SteamBot {
     confit(path.resolve('config/')).create((err, config) => {
       if (err) return cb(err)
 
-      // Build command parser
       this._parser = yargs()
-      this._parser.command(dice(this))
-      this._parser.command(uptime(this))
-      this._parser.help()
-      this._parser.version()
+      this._parser.command({
+        'command': config.get('cmd') + ' [cmd]',
+        'builder': yargs => {
+          const cmds = path.join(__dirname, 'plugins/cmds/')
+          yargs.commandDir(cmds, { 'visit': cmd => cmd(this) })
+          // yargs.help()
+          // yargs.version()
+        }
+      })
 
       this._client.logOn(config.get('login'))
-      this._client.on('loggedOn', response => {
+      this._client.on('loggedOn', (response, parental) => {
         this._client.setPersona(SteamUser.EPersonaState.Online)
         cb()
       })


### PR DESCRIPTION
Add a root command to which all additional commands are added as
subcommands.

Temporarily disable the `--help` and `--version` options, as they cause
the bot to crash.

Refs https://github.com/yargs/yargs/issues/776