### PR TITLE
feat(bot): Add whitelist/blacklist support

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,3 +1,5 @@
 {
-  "cmd": "!bot <cmd>"
+  "cmd": "!bot <cmd>",
+  "blacklist": [],
+  "whitelist": []
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -6,6 +6,7 @@
 const path = require('path')
 
 // Node packaged modules
+const lodash = require('lodash')
 const nconf = require('nconf')
 const SteamUser = require('steam-user')
 const yargs = require('yargs/yargs')
@@ -66,7 +67,7 @@ class SteamBot {
       })
 
       this._client.logOn(data.login)
-      this._client.on('loggedOn', (response, parental) => {
+      this._client.once('loggedOn', (response, parental) => {
         this._client.setPersona(SteamUser.EPersonaState.Online)
         cb()
       })
@@ -82,7 +83,7 @@ class SteamBot {
   **/
   stop (cb) {
     this._client.logOff()
-    this._client.on('disconnected', (eresult, msg) => {
+    this._client.once('disconnected', (eresult, msg) => {
       eresult === SteamUser.EResult.Invalid
         ? cb(new Error(msg))
         : cb()
@@ -104,6 +105,58 @@ class SteamBot {
         this._client.chatMsg(context.room, output)
       }
     })
+  }
+
+  /**
+   * Whitelist a Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving whitelist
+   * @returns {void}
+  **/
+  whitelist (steamId, cb) {
+    this._store.get('whitelist').push(steamId)
+    this._store.save(cb)
+  }
+
+  /**
+   * Unwhitelist a Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving whitelist
+   * @returns {void}
+  **/
+  unwhitelist (steamId, cb) {
+    lodash.pull(this._store.get('whitelist'), steamId)
+    this._store.save(cb)
+  }
+
+  /**
+   * Blacklist a Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving blacklist
+   * @returns {void}
+  **/
+  blacklist (steamId, cb) {
+    this._store.get('blacklist').push(steamId)
+    this._store.save(cb)
+  }
+
+  /**
+   * Unblacklist a Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving blacklist
+   * @returns {void}
+  **/
+  unblacklist (steamId, cb) {
+    lodash.pull(this._store.get('blacklist'), steamId)
+    this._store.save(cb)
   }
 
   //

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "chance": "^1.0.0",
+    "lodash": "^4.0.0",
     "nconf": "^0.8.0",
     "steam-user": "^3.0.0",
     "yargs": "^6.1.1"

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,3 +1,5 @@
 {
-  "cmd": "!test <cmd>"
+  "cmd": "!test <cmd>",
+  "blacklist": [],
+  "whitelist": []
 }

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -19,22 +19,22 @@ const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
 // -- Tests --------------------------------------------------------------------
 
 tap.test('SteamBot', tap => {
-  tap.plan(3)
+  tap.plan(7)
 
   //
   // Methods
   //
 
-  tap.test('#start should not pass an error', tap => {
-    const bot = new SteamBot(path.resolve('../fixtures/config.json'))
+  tap.test('#start should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
       tap.end()
     })
   })
 
-  tap.test('#stop should not pass an error', tap => {
-    const bot = new SteamBot(path.resolve('../fixtures/config.json'))
+  tap.test('#stop should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
       bot.stop(err => {
@@ -44,11 +44,55 @@ tap.test('SteamBot', tap => {
     })
   })
 
-  tap.test('#exec should not pass an error', tap => {
-    const bot = new SteamBot(path.resolve('../fixtures/config.json'))
+  tap.test('#exec should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.exec('--help', (err, argv, output) => {
+      bot.exec('cmd', (err, argv, output) => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#whitelist should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.whitelist('ID', err => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#unwhitelist should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.unwhitelist('ID', err => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#blacklist should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.blacklist('ID', err => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#unblacklist should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.unblacklist('ID', err => {
         tap.error(err)
         tap.end()
       })


### PR DESCRIPTION
Add support for a whitelist and blacklist that can be used to allow
or disallow certain users from accessing certain commands or other
sensitive features.