### PR TITLE
feat(cmd): Add `kill` command

### DIFF
--- a/lib/plugins/cmds/kill.js
+++ b/lib/plugins/cmds/kill.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Terminate the bot process.
+ *
+ * @since 0.1.0
+ * @param {SteamBot} bot - Bot instance
+ * @returns {Object} Command object in yargs format
+**/
+function kill (bot) {
+  return {
+    'command': 'kill',
+    'description': 'Terminate bot process',
+
+    builder (yargs) {
+      yargs.check((argv, aliases) => bot.whitelisted(argv.sender))
+    },
+
+    handler (argv) {
+      bot.stop(err => {
+        if (err) throw err
+      })
+    }
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = kill


### PR DESCRIPTION
Add command to gracefully terminate the bot through a Steam chat. Only
users added to the bot's whitelist may use this command.