### PR TITLE
feat(bot): Add mute list

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,5 +1,6 @@
 {
   "cmd": "!bot <cmd>",
+  "mute": [],
   "blacklist": [],
   "whitelist": []
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -108,18 +108,53 @@ class SteamBot {
   }
 
   /**
-   * Check if whitelist includes Steam ID.
+   * Check if the bot is muted for a given Steam ID.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID
-   * @returns {boolean} True if whitelist includes Steam ID, else false
+   * @returns {boolean} True if bot is muted for a given Steam ID, else false
+  **/
+  muted (steamId) {
+    return lodash.includes(this._store.get('mute'), steamId)
+  }
+
+  /**
+   * Mute the bot for a given Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving mute list
+   * @returns {void}
+  **/
+  mute (steamId, cb) {
+    this._list('mute', steamId, cb)
+  }
+
+  /**
+   * Unmute the bot for a given Steam ID.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @param {Function} cb - Continuation function after saving mute list
+   * @returns {void}
+  **/
+  unmute (steamId, cb) {
+    this._unlist('mute', steamId, cb)
+  }
+
+  /**
+   * Check if a given Steam ID is whitelisted.
+   *
+   * @since 0.1.0
+   * @param {string} steamId - Steam ID
+   * @returns {boolean} True if a given Steam ID is whitelisted, else false
   **/
   whitelisted (steamId) {
     return lodash.includes(this._store.get('whitelist'), steamId)
   }
 
   /**
-   * Whitelist a Steam ID.
+   * Whitelist a given Steam ID.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID
@@ -131,7 +166,7 @@ class SteamBot {
   }
 
   /**
-   * Unwhitelist a Steam ID.
+   * Unwhitelist a given Steam ID.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID
@@ -143,18 +178,18 @@ class SteamBot {
   }
 
   /**
-   * Check if blacklist includes Steam ID.
+   * Check if a given Steam ID is blacklisted.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID
-   * @returns {boolean} True if blacklist includes Steam ID, else false
+   * @returns {boolean} True if given Steam ID is blacklisted, else false
   **/
   blacklisted (steamId) {
     return lodash.includes(this._store.get('blacklist'), steamId)
   }
 
   /**
-   * Blacklist a Steam ID.
+   * Blacklist a given Steam ID.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID
@@ -166,7 +201,7 @@ class SteamBot {
   }
 
   /**
-   * Unblacklist a Steam ID.
+   * Unblacklist a given Steam ID.
    *
    * @since 0.1.0
    * @param {string} steamId - Steam ID

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,5 +1,6 @@
 {
   "cmd": "!test <cmd>",
+  "mute": [],
   "blacklist": [],
   "whitelist": []
 }

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -19,7 +19,7 @@ const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
 // -- Tests --------------------------------------------------------------------
 
 tap.test('SteamBot', tap => {
-  tap.plan(9)
+  tap.plan(12)
 
   //
   // Methods
@@ -49,6 +49,37 @@ tap.test('SteamBot', tap => {
     bot.start(err => {
       tap.error(err)
       bot.exec('cmd', (err, argv, output) => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#muted should return false', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      tap.false(bot.muted('ID'))
+      tap.end()
+    })
+  })
+
+  tap.test('#mute should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.mute('ID', err => {
+        tap.error(err)
+        tap.end()
+      })
+    })
+  })
+
+  tap.test('#unmute should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.unmute('ID', err => {
         tap.error(err)
         tap.end()
       })


### PR DESCRIPTION
Add a list of Steam IDs for which the bot has been muted. The bot will
not send any messages directly to the listed Steam IDs.