### PR TITLE
refactor(bot): Pass Steam ID strings

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -39,7 +39,7 @@ function dice (bot) {
     },
 
     handler (argv) {
-      bot._client.chatMsg(argv.room, argv.roll)
+      bot._client.chatMsg(argv.roomId, argv.roll)
     }
   }
 }

--- a/lib/plugins/cmds/uptime.js
+++ b/lib/plugins/cmds/uptime.js
@@ -19,7 +19,7 @@ function uptime (bot) {
     'description': 'Show bot uptime',
 
     handler (argv) {
-      bot._client.chatMsg(argv.room, `Bot uptime: ${process.uptime()}s`)
+      bot._client.chatMsg(argv.roomId, `Bot uptime: ${process.uptime()}s`)
     }
   }
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -37,7 +37,7 @@ class SteamBot {
 
     this._client = new SteamUser()
     this._client.on('friendOrChatMessage', (sender, msg, room) => {
-      this.exec(msg, { sender, room })
+      this.exec(msg, sender.getSteamID64(), room.getSteamID64())
     })
   }
 
@@ -95,34 +95,35 @@ class SteamBot {
    *
    * @since 0.1.0
    * @param {string} cmd - Raw command
-   * @param {Object} context - Message context information
+   * @param {string} senderId - Command issuer Steam ID
+   * @param {string} roomId - Room Steam ID
    * @returns {void}
   **/
-  exec (cmd, context) {
-    this._parser.parse(cmd, context, (err, argv, output) => {
+  exec (cmd, senderId, roomId) {
+    this._parser.parse(cmd, { senderId, roomId }, (err, argv, output) => {
       if (err && !output) throw err
       if (output) {
-        this._client.chatMsg(context.room, output)
+        this._client.chatMsg(roomId, output)
       }
     })
   }
 
   /**
-   * Check if the bot is muted for a given Steam ID.
+   * Check if the bot is muted for a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
-   * @returns {boolean} True if bot is muted for a given Steam ID, else false
+   * @param {string} steamId - User or group Steam ID
+   * @returns {boolean} True if bot is muted for a user or group, else false
   **/
   muted (steamId) {
     return lodash.includes(this._store.get('mute'), steamId)
   }
 
   /**
-   * Mute the bot for a given Steam ID.
+   * Mute the bot for a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving mute list
    * @returns {void}
   **/
@@ -131,10 +132,10 @@ class SteamBot {
   }
 
   /**
-   * Unmute the bot for a given Steam ID.
+   * Unmute the bot for a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving mute list
    * @returns {void}
   **/
@@ -143,21 +144,21 @@ class SteamBot {
   }
 
   /**
-   * Check if a given Steam ID is whitelisted.
+   * Check if a user or group is whitelisted.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
-   * @returns {boolean} True if a given Steam ID is whitelisted, else false
+   * @param {string} steamId - User or group Steam ID
+   * @returns {boolean} True if a user or group is whitelisted, else false
   **/
   whitelisted (steamId) {
     return lodash.includes(this._store.get('whitelist'), steamId)
   }
 
   /**
-   * Whitelist a given Steam ID.
+   * Whitelist a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving whitelist
    * @returns {void}
   **/
@@ -166,10 +167,10 @@ class SteamBot {
   }
 
   /**
-   * Unwhitelist a given Steam ID.
+   * Unwhitelist a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving whitelist
    * @returns {void}
   **/
@@ -178,21 +179,21 @@ class SteamBot {
   }
 
   /**
-   * Check if a given Steam ID is blacklisted.
+   * Check if a user or group is blacklisted.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
-   * @returns {boolean} True if given Steam ID is blacklisted, else false
+   * @param {string} steamId - User or group Steam ID
+   * @returns {boolean} True if a user or group is blacklisted, else false
   **/
   blacklisted (steamId) {
     return lodash.includes(this._store.get('blacklist'), steamId)
   }
 
   /**
-   * Blacklist a given Steam ID.
+   * Blacklist a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving blacklist
    * @returns {void}
   **/
@@ -201,10 +202,10 @@ class SteamBot {
   }
 
   /**
-   * Unblacklist a given Steam ID.
+   * Unblacklist a user or group.
    *
    * @since 0.1.0
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving blacklist
    * @returns {void}
   **/
@@ -241,11 +242,11 @@ class SteamBot {
   **/
 
   /**
-   * Add Steam ID to permissions list.
+   * Add a user or group to permissions list.
    *
    * @private
    * @param {string} name - Permissions list name
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving permissions list
    * @returns {void}
   **/
@@ -255,11 +256,11 @@ class SteamBot {
   }
 
   /**
-   * Remove Steam ID from permissions list.
+   * Remove a user or group from permissions list.
    *
    * @private
    * @param {string} name - Permissions list name
-   * @param {string} steamId - Steam ID
+   * @param {string} steamId - User or group Steam ID
    * @param {Function} cb - Continuation function after saving permissions list
    * @returns {void}
   **/

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -48,10 +48,8 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.exec('cmd', (err, argv, output) => {
-        tap.error(err)
-        tap.end()
-      })
+      bot.exec('cmd', 'ID', 'ID')
+      tap.end()
     })
   })
 


### PR DESCRIPTION
Pass Steam ID strings instead of whole SteamID objects. Strings are
easier to work with and all client methods take either as inputs anyway.