### PR TITLE
feat(bot): Add ability to mute responses

### DIFF
--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -39,7 +39,7 @@ function dice (bot) {
     },
 
     handler (argv) {
-      bot._client.chatMsg(argv.roomId, argv.roll)
+      bot.respond(argv.chatId, argv.roll)
     }
   }
 }

--- a/lib/plugins/cmds/uptime.js
+++ b/lib/plugins/cmds/uptime.js
@@ -19,7 +19,7 @@ function uptime (bot) {
     'description': 'Show bot uptime',
 
     handler (argv) {
-      bot._client.chatMsg(argv.roomId, `Bot uptime: ${process.uptime()}s`)
+      bot.respond(argv.chatId, `Bot uptime: ${process.uptime()}s`)
     }
   }
 }

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -36,8 +36,8 @@ class SteamBot {
     this._store.defaults(defaults)
 
     this._client = new SteamUser()
-    this._client.on('friendOrChatMessage', (sender, msg, room) => {
-      this.exec(msg, sender.getSteamID64(), room.getSteamID64())
+    this._client.on('friendOrChatMessage', (sender, msg, chat) => {
+      this.exec(msg, sender.getSteamID64(), chat.getSteamID64())
     })
   }
 
@@ -91,56 +91,70 @@ class SteamBot {
   }
 
   /**
+   * Respond a message to a user or group chat. If the bot has been muted for
+   * the given chat, then do nothing.
+   *
+   * @since 0.1.0
+   * @param {string} chatId - User or group chat Steam ID
+   * @param {string} msg - Message to respond
+   * @returns {void}
+  **/
+  respond (chatId, msg) {
+    if (this.muted(chatId)) return
+    this._client.chatMsg(chatId, msg)
+  }
+
+  /**
    * Execute a command.
    *
    * @since 0.1.0
    * @param {string} cmd - Raw command
    * @param {string} senderId - Command issuer Steam ID
-   * @param {string} roomId - Room Steam ID
+   * @param {string} chatId - User or group chat Steam ID
    * @returns {void}
   **/
-  exec (cmd, senderId, roomId) {
-    this._parser.parse(cmd, { senderId, roomId }, (err, argv, output) => {
+  exec (cmd, senderId, chatId) {
+    this._parser.parse(cmd, { senderId, chatId }, (err, argv, output) => {
       if (err && !output) throw err
       if (output) {
-        this._client.chatMsg(roomId, output)
+        this.respond(chatId, output)
       }
     })
   }
 
   /**
-   * Check if the bot is muted for a user or group.
+   * Check if the bot is muted for a user or group chat.
    *
    * @since 0.1.0
-   * @param {string} steamId - User or group Steam ID
-   * @returns {boolean} True if bot is muted for a user or group, else false
+   * @param {string} chatId - User or group chat Steam ID
+   * @returns {boolean} True if bot is muted for a given chat, else false
   **/
-  muted (steamId) {
-    return lodash.includes(this._store.get('mute'), steamId)
+  muted (chatId) {
+    return lodash.includes(this._store.get('mute'), chatId)
   }
 
   /**
-   * Mute the bot for a user or group.
+   * Mute the bot for a user or group chat.
    *
    * @since 0.1.0
-   * @param {string} steamId - User or group Steam ID
+   * @param {string} chatId - User or group chat Steam ID
    * @param {Function} cb - Continuation function after saving mute list
    * @returns {void}
   **/
-  mute (steamId, cb) {
-    this._list('mute', steamId, cb)
+  mute (chatId, cb) {
+    this._list('mute', chatId, cb)
   }
 
   /**
-   * Unmute the bot for a user or group.
+   * Unmute the bot for a user or group chat.
    *
    * @since 0.1.0
-   * @param {string} steamId - User or group Steam ID
+   * @param {string} chatId - User or group chat Steam ID
    * @param {Function} cb - Continuation function after saving mute list
    * @returns {void}
   **/
-  unmute (steamId, cb) {
-    this._unlist('mute', steamId, cb)
+  unmute (chatId, cb) {
+    this._unlist('mute', chatId, cb)
   }
 
   /**

--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -19,7 +19,7 @@ const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
 // -- Tests --------------------------------------------------------------------
 
 tap.test('SteamBot', tap => {
-  tap.plan(12)
+  tap.plan(13)
 
   //
   // Methods
@@ -44,11 +44,20 @@ tap.test('SteamBot', tap => {
     })
   })
 
+  tap.test('#respond should not error', tap => {
+    const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
+    bot.start(err => {
+      tap.error(err)
+      bot.respond('76561197962144253', 'msg')
+      tap.end()
+    })
+  })
+
   tap.test('#exec should not error', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.exec('cmd', 'ID', 'ID')
+      bot.exec('cmd', '76561197962144253', '76561197962144253')
       tap.end()
     })
   })
@@ -57,7 +66,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      tap.false(bot.muted('ID'))
+      tap.false(bot.muted('76561197962144253'))
       tap.end()
     })
   })
@@ -66,7 +75,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.mute('ID', err => {
+      bot.mute('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })
@@ -77,7 +86,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.unmute('ID', err => {
+      bot.unmute('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })
@@ -88,7 +97,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      tap.false(bot.whitelisted('ID'))
+      tap.false(bot.whitelisted('76561197962144253'))
       tap.end()
     })
   })
@@ -97,7 +106,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.whitelist('ID', err => {
+      bot.whitelist('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })
@@ -108,7 +117,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.unwhitelist('ID', err => {
+      bot.unwhitelist('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })
@@ -119,7 +128,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      tap.false(bot.blacklisted('ID'))
+      tap.false(bot.blacklisted('76561197962144253'))
       tap.end()
     })
   })
@@ -128,7 +137,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.blacklist('ID', err => {
+      bot.blacklist('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })
@@ -139,7 +148,7 @@ tap.test('SteamBot', tap => {
     const bot = new SteamBot(path.join(__dirname, '../fixtures/config.json'))
     bot.start(err => {
       tap.error(err)
-      bot.unblacklist('ID', err => {
+      bot.unblacklist('76561197962144253', err => {
         tap.error(err)
         tap.end()
       })


### PR DESCRIPTION
Add a `respond` method to use for responding messages to a Steam chat.
This method checks if the bot has been muted for the given chat, and can
be further extended in the future to allow throttling in a single place.