### PR TITLE
fix(bot): Fix permissions lists not saving

### DIFF
--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -265,7 +265,10 @@ class SteamBot {
    * @returns {void}
   **/
   _list (name, steamId, cb) {
-    this._store.get(name).push(steamId)
+    const list = this._store.get(name)
+    if (!lodash.includes(list, steamId)) {
+      this._store.set(name, lodash.concat(list, steamId))
+    }
     this._store.save(cb)
   }
 
@@ -279,7 +282,7 @@ class SteamBot {
    * @returns {void}
   **/
   _unlist (name, steamId, cb) {
-    lodash.pull(this._store.get(name), steamId)
+    this._store.set(name, lodash.without(this._store.get(name), steamId))
     this._store.save(cb)
   }
 }


### PR DESCRIPTION
Remove attempt at "clever" code that tried to update a list directly
rather than call the `set` method. This was buggy, and the code wasn't
intuitive either.