### PR TITLE
fix(cmd): Fix flagless args being parsed as numbers

### DIFF
--- a/lib/plugins/cmds/blacklist.js
+++ b/lib/plugins/cmds/blacklist.js
@@ -24,7 +24,7 @@ function blacklist (bot) {
 
     builder (yargs) {
       yargs.check((argv, aliases) => bot.whitelisted(argv.senderId))
-      yargs.option('steamId', { 'type': 'string' })
+      yargs.string('_') // Parse flagless args as strings
     },
 
     handler (argv) {

--- a/lib/plugins/cmds/dice.js
+++ b/lib/plugins/cmds/dice.js
@@ -34,7 +34,7 @@ function dice (bot) {
     'description': 'Simulate a dice roll',
 
     builder (yargs) {
-      yargs.option('roll', { 'default': '1d6', 'type': 'string' })
+      yargs.option('roll', { 'default': '1d6' })
       yargs.coerce('roll', arg => chance().rpg(arg).join(' '))
     },
 


### PR DESCRIPTION
`yargs` doesn't quite support positional arguments as well as regular
options, so attemtping to set type, etc. doesn't work. Luckily, there's
a work-around that forcess all flagless args to be parsed as strings.