### PR TITLE
test(fixture): Remove empty permissions lists

### DIFF
--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,6 +1,3 @@
 {
-  "cmd": "!test <cmd>",
-  "mute": [],
-  "whitelist": [],
-  "blacklist": []
+  "cmd": "!test <cmd>"
 }


### PR DESCRIPTION
Remove empty permissions lists from the config fixture, as they are
already loaded in the defaults.