### PR TITLE
feat(cmd): Add `mute` command

### DIFF
--- a/lib/plugins/cmds/mute.js
+++ b/lib/plugins/cmds/mute.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Mute the bot for a given user or group.
+ *
+ * Expects one (1) required argument:
+ *  * steam-id
+ *    - 64-bit representation of the user or group Steam ID.
+ *
+ * @since 0.1.0
+ * @param {SteamBot} bot - Bot instance
+ * @returns {Object} Command object in yargs format
+ * @example
+ *
+ * mute 76561197962144253
+ * // => 'Permissions updated'
+**/
+function mute (bot) {
+  return bot._permissions('mute')
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = mute


### PR DESCRIPTION
A command to mute the bot for a given user or group by Steam ID.