### PR TITLE
feat(cmd): Add `--remove` option

### DIFF
--- a/lib/plugins/cmds/blacklist.js
+++ b/lib/plugins/cmds/blacklist.js
@@ -16,6 +16,12 @@
  *
  * blacklist 76561197962144253
  * // => 'Permissions updated'
+ *
+ * blacklist 76561197962144253 -r
+ * // => 'Permissions updated'
+ *
+ * blacklist 76561197962144253 --remove
+ * // => 'Permissions updated'
 **/
 function blacklist (bot) {
   return bot._permissions('blacklist')

--- a/lib/plugins/cmds/mute.js
+++ b/lib/plugins/cmds/mute.js
@@ -16,6 +16,12 @@
  *
  * mute 76561197962144253
  * // => 'Permissions updated'
+ *
+ * mute 76561197962144253 -r
+ * // => 'Permissions updated'
+ *
+ * mute 76561197962144253 --remove
+ * // => 'Permissions updated'
 **/
 function mute (bot) {
   return bot._permissions('mute')

--- a/lib/plugins/cmds/whitelist.js
+++ b/lib/plugins/cmds/whitelist.js
@@ -16,6 +16,12 @@
  *
  * whitelist 76561197962144253
  * // => 'Permissions updated'
+ *
+ * whitelist 76561197962144253 -r
+ * // => 'Permissions updated'
+ *
+ * whitelist 76561197962144253 --remove
+ * // => 'Permissions updated'
 **/
 function whitelist (bot) {
   return bot._permissions('whitelist')

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -300,10 +300,14 @@ class SteamBot {
       'builder': yargs => {
         yargs.check((argv, aliases) => this.whitelisted(argv.senderId))
         yargs.string('_') // Parse flagless args as strings
+        yargs.option('remove', { 'alias': 'r', 'type': 'boolean' })
       },
 
       'handler': argv => {
-        this[cmd](argv.steamId, err => {
+        const method = argv.remove
+          ? `un${cmd}`
+          : cmd
+        this[method](argv.steamId, err => {
           err
             ? this.respond(argv.chatId, err.message)
             : this.respond(argv.chatId, 'Permissions updated')


### PR DESCRIPTION
Add `--remove` option to permissions commands. A whitelisted user can
now remove a Steam ID from a permissions list using the respective
permissions command by applying the `--remove` (alias `-r`) boolean
option.