### PR TITLE
refactor(bot): Separate command builder / handler

### DIFF
--- a/lib/plugins/cmds/blacklist.js
+++ b/lib/plugins/cmds/blacklist.js
@@ -18,7 +18,12 @@
  * // => 'Permissions updated'
 **/
 function blacklist (bot) {
-  return bot._permissions('blacklist')
+  return {
+    'command': 'blacklist <steam-id>',
+    'description': 'Blacklist a user or group',
+    'builder': bot._cmdBuilder,
+    'handler': bot._cmdHandler(bot.blacklist, bot.unblacklist)
+  }
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/lib/plugins/cmds/mute.js
+++ b/lib/plugins/cmds/mute.js
@@ -18,7 +18,12 @@
  * // => 'Permissions updated'
 **/
 function mute (bot) {
-  return bot._permissions('mute')
+  return {
+    'command': 'mute <steam-id>',
+    'description': 'Mute a user or group',
+    'builder': bot._cmdBuilder,
+    'handler': bot._cmdHandler(bot.mute, bot.unmute)
+  }
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/lib/plugins/cmds/whitelist.js
+++ b/lib/plugins/cmds/whitelist.js
@@ -18,7 +18,12 @@
  * // => 'Permissions updated'
 **/
 function whitelist (bot) {
-  return bot._permissions('whitelist')
+  return {
+    'command': 'whitelist <steam-id>',
+    'description': 'Whitelist a user or group',
+    'builder': bot._cmdBuilder,
+    'handler': bot._cmdHandler(bot.whitelist, bot.unwhitelist)
+  }
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -285,30 +285,36 @@ class SteamBot {
   }
 
   /**
-   * Dynamically create command to add or remove a user or group to or from a
-   * permissions list.
+   * Dynamically create a builder function for a permissions list command.
    *
    * @private
-   * @param {string} cmd - Command name
-   * @returns {Object} Command object in yargs format
+   * @param {Yargs} yargs - Yargs instance
+   * @returns {void}
   **/
-  _permissions (cmd) {
-    return {
-      'command': `${cmd} <steam-id>`,
-      'description': `${lodash.capitalize(cmd)} a user or group`,
+  _cmdBuilder (yargs) {
+    yargs.check((argv, aliases) => this.whitelisted(argv.senderId))
+    yargs.option('_', { 'type': 'string' }) // Parse flagless args as strings
+    yargs.option('remove', { 'alias': 'r', 'type': 'boolean' })
+  }
 
-      'builder': yargs => {
-        yargs.check((argv, aliases) => this.whitelisted(argv.senderId))
-        yargs.string('_') // Parse flagless args as strings
-      },
-
-      'handler': argv => {
-        this[cmd](argv.steamId, err => {
-          err
-            ? this.respond(argv.chatId, err.message)
-            : this.respond(argv.chatId, 'Permissions updated')
-        })
-      }
+  /**
+   * Dynamically create a handler function for a permissions list command.
+   *
+   * @private
+   * @param {Function} list - Add a user or group to list
+   * @param {Function} unlist - Remove a user or group to list
+   * @returns {Function} Command handler
+  **/
+  _cmdHandler (list, unlist) {
+    return argv => {
+      const func = argv.remove
+        ? unlist
+        : list
+      func(argv.steamId, err => {
+        err
+          ? this.respond(argv.chatId, err.message)
+          : this.respond(argv.chatId, 'Permissions updated')
+      })
     }
   }
 }


### PR DESCRIPTION
Separate permissions list command builder / handler creation to allow
command names, descriptions, and methods to be specified directly.