### PR TITLE
feat(trigger): Add `execCmd` trigger

### DIFF
--- a/lib/plugins/triggers/exec-cmd.js
+++ b/lib/plugins/triggers/exec-cmd.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Execute a command.
+ *
+ * @since 0.1.0
+ * @param {SteamBot} bot - Steam bot
+ * @returns {Object} Object containing Steam events and their handlers
+**/
+function execCmd (bot) {
+  return {
+    friendOrChatMessage (sender, msg, chat) {
+      bot.exec(msg, sender.getSteamID64(), chat.getSteamID64())
+    }
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = execCmd

--- a/lib/steam-bot.js
+++ b/lib/steam-bot.js
@@ -8,6 +8,7 @@ const path = require('path')
 // Node packaged modules
 const lodash = require('lodash')
 const nconf = require('nconf')
+const requireAll = require('require-all')
 const SteamUser = require('steam-user')
 const yargs = require('yargs/yargs')
 
@@ -36,8 +37,11 @@ class SteamBot {
     this._store.defaults(defaults)
 
     this._client = new SteamUser()
-    this._client.on('friendOrChatMessage', (sender, msg, chat) => {
-      this.exec(msg, sender.getSteamID64(), chat.getSteamID64())
+    requireAll({
+      'dirname': path.join(__dirname, 'plugins/triggers/'),
+      'resolve': events => lodash.forOwn(events(this), (handler, event) => {
+        this._client.on(event, handler)
+      })
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chance": "^1.0.0",
     "lodash": "^4.0.0",
     "nconf": "^0.8.0",
+    "require-all": "^2.0.0",
     "steam-user": "^3.0.0",
     "yargs": "^6.1.1"
   },


### PR DESCRIPTION
Add trigger to listen to chat messages for command strings, then
execute the given command.

This functionality already existed, however, triggers will now be found
in the 'plugins/' directory.