### PR TITLE
test(bot): Add `nconf` stub

### DIFF
--- a/test/lib/steam-bot.test.js
+++ b/test/lib/steam-bot.test.js
@@ -10,11 +10,15 @@ const proxyquire = require('proxyquire')
 const tap = require('tap')
 
 // Local modules
+const nconf = require('../stubs/nconf.stub')
 const SteamUser = require('../stubs/steam-user.stub')
 
-// -- Helpers ------------------------------------------------------------------
+// -- Stubs --------------------------------------------------------------------
 
-const SteamBot = proxyquire('../../lib/steam-bot', { 'steam-user': SteamUser })
+const SteamBot = proxyquire('../../lib/steam-bot', {
+  nconf,
+  'steam-user': SteamUser
+})
 
 // -- Tests --------------------------------------------------------------------
 

--- a/test/stubs/nconf.stub.js
+++ b/test/stubs/nconf.stub.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// -- Dependencies -------------------------------------------------------------
+
+// Node packaged modules
+const nconf = require('nconf')
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Provider stub.
+**/
+class Provider extends nconf.Provider {
+
+  /**
+   * Provider#save stub.
+   *
+   * @private
+   * @param {Function} cb - Continuation function
+   * @returns {void}
+  **/
+  save (cb) {
+    process.nextTick(_ => {
+      cb()
+    })
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports.Provider = Provider


### PR DESCRIPTION
Add stub to prevent saving over any config fixture files. Proxyquire
doesn't seem to intelligently handle classes that are properties of a
dependency, so we have to extend the `nconf` provider directly.