### PR TITLE
chore(package): Allow trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ root = true
   charset = utf-8
   trim_trailing_whitespace = true
   insert_final_newline = true
+
+[*.md]
+  trim_trailing_whitespace = false


### PR DESCRIPTION
Allow trailing whitespace in EditorConfig for markdown.