### PR TITLE
feat(trigger): Add `acceptChatInvite` trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning][semver].
 
 ### New Features
  - Bot: Allow joining / leaving a user or group chat
+ - Trigger: `acceptChatInvite` - Accept a chat invite
 
 ## 0.1.0 - 2017-03-07
 

--- a/lib/plugins/triggers/accept-chat-invite.js
+++ b/lib/plugins/triggers/accept-chat-invite.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// -- Public Interface ---------------------------------------------------------
+
+/**
+ * Accept a chat invite.
+ *
+ * @since 0.2.0
+ * @param {SteamBot} bot - Steam bot
+ * @returns {Object} Object containing Steam events and their handlers
+**/
+function acceptChatInvite (bot) {
+  return {
+    chatInvite (inviter, chat, name) {
+      const inviterId = inviter.getSteamID64()
+      if (bot.blacklisted(inviterId)) return
+
+      const chatId = chat.getSteamID64()
+      if (bot.blacklisted(chatId)) return
+
+      bot.join(chatId, err => {
+        if (err) bot.respond(inviterId, err.message)
+      })
+    }
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+module.exports = acceptChatInvite


### PR DESCRIPTION
Add a trigger to accept incoming chat invites. The invite is ignored if
either the inviter or the chat to which the bot was invited are
blacklisted.