### PR TITLE
style(stub): Rename callback

### DIFF
--- a/test/stubs/nconf.stub.js
+++ b/test/stubs/nconf.stub.js
@@ -15,12 +15,12 @@ class Provider extends nconf.Provider {
    * Provider#save stub.
    *
    * @private
-   * @param {Function} cb - Continuation function
+   * @param {Function} func - Continuation function
    * @returns {void}
   **/
-  save (cb) {
+  save (func) {
     process.nextTick(_ => {
-      cb()
+      func()
     })
   }
 }

--- a/test/stubs/steam-user.stub.js
+++ b/test/stubs/steam-user.stub.js
@@ -66,12 +66,12 @@ class SteamUser extends EventEmitter {
    *
    * @private
    * @param {string} userId - User Steam ID
-   * @param {Function} cb - Continuation function
+   * @param {Function} func - Continuation function
    * @returns {void}
   **/
-  addFriend (userId, cb) {
+  addFriend (userId, func) {
     process.nextTick(_ => {
-      cb()
+      func()
     })
   }
 }


### PR DESCRIPTION
Since `SteamUser` doesn't follow standard conventions, rename `cb` to
`func` to prevent future linting issues.